### PR TITLE
🐛  if not used semicolon

### DIFF
--- a/consoleClear.js
+++ b/consoleClear.js
@@ -37,7 +37,7 @@ class ConsoleClear {
             .document
             .getText();
 
-        const regex = /(console.log\(\)|console.log\(.+\));/;
+        const regex = /(console.log\(\)|console.log\(.+\))/;
 
         let endOfFile = false;
         let iteratedLine = 0;


### PR DESCRIPTION
Hi Will Holmes

if you can consider this, thanks

* cannot find console.log if semicolon is not used